### PR TITLE
Fix GitHub page deployment

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,11 +1,6 @@
 name: BiRD-build-documentation
  
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'docs/**'
-      - '.github/workflows/docs_pages.yml'
   pull_request:
      branches: [main]
      paths:

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -5,7 +5,7 @@ on:
      branches: [main]
      paths:
       - 'docs/**'
-      - '.github/workflows/docs_pages.yml'
+      - '.github/workflows/build_docs.yml'
  
 jobs:
  

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -2,7 +2,7 @@ name: BiRD-build-documentation
  
 on:
   pull_request:
-     branches: [main]
+     branches: [ main ]
      paths:
       - 'docs/**'
       - '.github/workflows/build_docs.yml'

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -9,8 +9,10 @@ on:
  
 jobs:
  
-  build_docs:
+  build_deploy_docs:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,13 +33,6 @@ jobs:
           cd docs
           make html
 
-  deploy_docs:
-    needs: build_docs
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
- 
-    steps:
       - name: deploy
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main, docfix ]
     paths:
       - 'docs/**'
-      - '.github/workflows/docs_pages.yml'
+      - '.github/workflows/deploy_docs.yml'
  
 jobs:
  

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -2,7 +2,7 @@ name: BiRD-deploy-documentation
  
 on:
   push:
-    branches: [ main, docfix ]
+    branches: [ main ]
     paths:
       - 'docs/**'
       - '.github/workflows/deploy_docs.yml'
@@ -33,7 +33,7 @@ jobs:
           cd docs
           make html
 
-      - name: deploy
+      - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -32,6 +32,7 @@ jobs:
           make html
 
   deploy_docs:
+    needs: build_docs
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -2,7 +2,7 @@ name: BiRD-deploy-documentation
  
 on:
   push:
-    branches: [ main ]
+    branches: [ main, docfix ]
     paths:
       - 'docs/**'
       - '.github/workflows/docs_pages.yml'


### PR DESCRIPTION
- `docs_pages.yml` was wrongly referenced while it was deleted
- upon push on main, don't call "build_docs.yml" since docs are build anyway before deployment
- build and deploy within the same action, it seems like `_build` was erased otherwise.

I tried the deployment if I push to `docfix` and it seemed to work, so I think it should be good now