### PR TITLE
Update numpy-stl and adhere to setuptools standard

### DIFF
--- a/bird/requirements.txt
+++ b/bird/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 prettyPlot
 ruamel_yaml
-numpy-stl==2.17.0
+numpy-stl>=3.2.0
 scipy
 corner
 jax

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["setuptools >= 64", "wheel"]
+build-backend = "setuptools.build_meta"
+

--- a/tests/preprocess/test_stl_patch.py
+++ b/tests/preprocess/test_stl_patch.py
@@ -5,10 +5,10 @@ import numpy as np
 from bird import BIRD_PRE_PATCH_TEMP_DIR
 from bird.meshing._mesh_tools import parseJsonFile
 from bird.preprocess.stl_patch.stl_bc import write_boundaries
-from bird.utilities.stl_plotting import plotSTL, pretty_labels
+from bird.utilities.stl_plotting import plotSTL, plt, pretty_labels
 
 
-def test_spider_sparger():
+def test_spider_sparger(verbose=False):
     input_dict = parseJsonFile(
         os.path.join(BIRD_PRE_PATCH_TEMP_DIR, "spider_spg/inlets_outlets.json")
     )
@@ -16,9 +16,11 @@ def test_spider_sparger():
     # plot
     axes = plotSTL("inlets.stl")
     pretty_labels("x", "y", zlabel="z", fontsize=14, ax=axes)
+    if verbose:
+        plt.show()
 
 
-def test_loop_reactor():
+def test_loop_reactor(verbose=False):
     input_dict = parseJsonFile(
         os.path.join(
             BIRD_PRE_PATCH_TEMP_DIR, "loop_reactor_expl/inlets_outlets.json"
@@ -28,9 +30,13 @@ def test_loop_reactor():
     # plot
     axes = plotSTL("inlets.stl")
     pretty_labels("x", "y", zlabel="z", fontsize=14, ax=axes)
+    axes = plotSTL("outlets.stl")
+    pretty_labels("x", "y", zlabel="z", fontsize=14, ax=axes)
+    if verbose:
+        plt.show()
 
 
-def test_loop_reactor_branch():
+def test_loop_reactor_branch(verbose=False):
     input_dict = parseJsonFile(
         os.path.join(
             BIRD_PRE_PATCH_TEMP_DIR, "loop_reactor_branch/inlets_outlets.json"
@@ -40,7 +46,11 @@ def test_loop_reactor_branch():
     # plot
     axes = plotSTL("inlets.stl")
     pretty_labels("x", "y", zlabel="z", fontsize=14, ax=axes)
+    axes = plotSTL("outlets.stl")
+    pretty_labels("x", "y", zlabel="z", fontsize=14, ax=axes)
+    if verbose:
+        plt.show()
 
 
 if __name__ == "__main__":
-    test_spider_sparger()
+    test_spider_sparger(verbose=True)


### PR DESCRIPTION
- numpy-stl now supports numpy 2 since 3.2.0, no need to hold the version back anymore
- setup.py develop is deprecated, adding pyproject.toml to adhere to the new standard